### PR TITLE
Changes for landlab pull request #370

### DIFF
--- a/landlab/components/drainage_density/cfuncs.pyx
+++ b/landlab/components/drainage_density/cfuncs.pyx
@@ -10,13 +10,14 @@ ctypedef np.double_t DTYPE_FLOAT_t
 
 
 @cython.boundscheck(False)
-def _calc_dists_to_channel(np.ndarray[DTYPE_INT_t, ndim=1] ch_network,
+def _calc_dists_to_channel(np.ndarray[np.uint8_t, ndim=1] ch_network,
                            np.ndarray[DTYPE_INT_t, ndim=1] flow_receivers,
                            np.ndarray[DTYPE_FLOAT_t, ndim=1] link_lengths,
                            np.ndarray[DTYPE_INT_t, ndim=1] stack_links,
                            np.ndarray[DTYPE_FLOAT_t, ndim=1] dist_to_ch,
                            DTYPE_INT_t num_nodes):
-    """
+    """Calculate distance to nearest channel.
+
     Calculate the distances to the closest channel node for all nodes in the
     grid.
 

--- a/landlab/components/drainage_density/drainage_density.py
+++ b/landlab/components/drainage_density/drainage_density.py
@@ -142,8 +142,8 @@ class DrainageDensity(Component):
         # Channel network
         self.channel_network_name = channel_network_name
         if channel_network_name in grid.at_node:
-            self.channel_network = grid.at_node[channel_network_name].astype(
-                int)
+            self.channel_network = grid.at_node[channel_network_name].view(
+                dtype=np.uint8)
             # for this component to work with Cython acceleration,
             # the channel_network must be int, not bool...
         else:

--- a/landlab/components/drainage_density/drainage_density.py
+++ b/landlab/components/drainage_density/drainage_density.py
@@ -12,8 +12,8 @@ import numpy as np
 
 
 class DrainageDensity(Component):
-    """
-    Calculate drainage density overa DEM.
+
+    """Calculate drainage density over a DEM.
 
     calc_drainage_density function returns drainage density for the model
     domain.
@@ -23,7 +23,7 @@ class DrainageDensity(Component):
 
     Written by C. Shobe on 7/11/2016
 
-    Construction:
+    Construction::
 
         DrainageDensity(grid, channel_network_name='string')
 
@@ -39,12 +39,14 @@ class DrainageDensity(Component):
     >>> from landlab import RasterModelGrid
     >>> from landlab.components.flow_routing import FlowRouter
     >>> from landlab.components import FastscapeEroder
+
     >>> mg = RasterModelGrid((10, 10), 1.0)
     >>> _ = mg.add_zeros('node', 'topographic__elevation')
+
     >>> np.random.seed(50)
     >>> noise = np.random.rand(100)
-    >>> mg['node']['topographic__elevation'] += noise
-    >>> mg['node']['topographic__elevation'] # doctest: +NORMALIZE_WHITESPACE
+    >>> mg.at_node['topographic__elevation'] += noise
+    >>> mg.at_node['topographic__elevation'] # doctest: +NORMALIZE_WHITESPACE
     array([ 0.49460165,  0.2280831 ,  0.25547392,  0.39632991,  0.3773151 ,
         0.99657423,  0.4081972 ,  0.77189399,  0.76053669,  0.31000935,
         0.3465412 ,  0.35176482,  0.14546686,  0.97266468,  0.90917844,
@@ -65,17 +67,20 @@ class DrainageDensity(Component):
         0.82165703,  0.73749168,  0.84034417,  0.4015291 ,  0.74862   ,
         0.55962945,  0.61323757,  0.29810165,  0.60237917,  0.42567684,
         0.53854438,  0.48672986,  0.49989164,  0.91745948,  0.26287702])
+
     >>> fr = FlowRouter(mg)
     >>> fsc = FastscapeEroder(mg, K_sp=.01, m_sp=.5, n_sp=1)
     >>> for x in range(100):
     ...     fr.run_one_step()
     ...     fsc.run_one_step(dt = 10.0)
     ...     mg.at_node['topographic__elevation'][mg.core_nodes] += .01
-    >>> channels = mg['node']['drainage_area'] > 5
-    >>> _ = mg.add_field('node', 'channel_network', channels)
+
+    >>> channels = mg.at_node['drainage_area'] > 5
+    >>> _ = mg.add_field('channel_network', channels, at='node')
+
     >>> dd = DrainageDensity(mg, channel_network_name='channel_network')
     >>> mean_drainage_density = dd.calc_drainage_density()
-    >>> print np.around(mean_drainage_density, 10)
+    >>> np.around(mean_drainage_density, 10)
     0.3831100571
     """
 

--- a/landlab/components/drainage_density/drainage_density.py
+++ b/landlab/components/drainage_density/drainage_density.py
@@ -80,8 +80,8 @@ class DrainageDensity(Component):
 
     >>> dd = DrainageDensity(mg, channel_network_name='channel_network')
     >>> mean_drainage_density = dd.calc_drainage_density()
-    >>> np.around(mean_drainage_density, 10)
-    0.3831100571
+    >>> np.isclose(mean_drainage_density, 0.3831100571)
+    True
     """
 
     _name = 'DrainageDensity'


### PR DESCRIPTION
This pull request makes some small changes in prep for pull request landlab/landlab#370.
-  Changed to use standard landlab conventions. For example,
  -  `grid.at_node` instead of `grid['node']`
  - `grid.add_zeros('z', at='node')` instead of `grid.add_zeros('node', 'z')`
-  Fixed doctest in Python 3.X by removing print statement in favor of `np.isclose`.
-  Create a view of the boolean `channel_network` array that is `uint8` to prevent a copy (boolean array elements are 1 byte long, `int`s are 4 or 8 bytes). Updated the corresponding Cython declaration.
- Tidy up `__init__` method.
